### PR TITLE
Keep dSM12 in circuit metering (only skip EOL dSM11)

### DIFF
--- a/custom_components/digitalstrom_smart/coordinator.py
+++ b/custom_components/digitalstrom_smart/coordinator.py
@@ -500,13 +500,15 @@ class DigitalStromCoordinator(DataUpdateCoordinator):
                     " | ".join(f"{c.get('name','?')} [hw={c.get('hwName','?')}] dsuid={(c.get('dSUID','') or '')[:18]}"
                                for c in all_circuits),
                 )
-                # NIEUWE-generatie dSM-meters meten (dSM20/dSM25). Oude dSM11/dSM12 worden
-                # niet gemeten (verzoek 12 jun). Mocht een dSM20 zich anders melden dan
-                # 'dSM20', dan zien we dat in de bovenstaande regel en passen we de filter aan.
+                # dSM20/dSM25 meten. dSM11 is EOL -> overslaan. dSM12 is wel ondersteund en
+                # levert via metering/getLatest geldige W en Wh (geverifieerd op een
+                # dSM12-only installatie) -> niet langer uitgesloten. De dSM-energie-corruptie
+                # die hier eerder speelde kwam van getSensorValue2-bus-starvation, die nu
+                # apart is opgelost (per-device power = events-only); dSM12-metering is veilig.
                 self._circuits = [
                     c for c in all_circuits
                     if c.get("hwName", "").startswith("dSM")
-                    and not c.get("hwName", "").startswith(("dSM11", "dSM12"))
+                    and not c.get("hwName", "").startswith("dSM11")
                 ]
                 _LOGGER.info(
                     "Gemeten dSM-meters (na filter): %d — %s",


### PR DESCRIPTION
## Problem

Since v3.7.4 (`per-device power events-only + dSM-metering alleen nieuwe-gen (dSM20/25)`), `fetch_circuit_data()` skips both **dSM11 and dSM12**:

```python
and not c.get("hwName", "").startswith(("dSM11", "dSM12"))
```

dSM11 is EOL, so skipping it is fine. But **dSM12 is still officially supported.** On an installation whose meters are all dSM12, this leaves **every** per-circuit power/energy sensor permanently `unavailable` (only the apartment total keeps working). The change isn''t mentioned in the release notes; the inline comment attributes it to a request (`verzoek`), and the follow-up v3.7.5 notes the regression couldn''t be reproduced locally because the only available hardware was dSM12.

## Why it''s safe to re-include dSM12

The energy corruption that motivated the restriction (`Metering pollLoop exceeded 1s budget` / `deltaEnergy: too long delay -> setting new baseline`) came from **`getSensorValue2` per-device polling starving the metering controller** — which was fixed *in the same release* by making per-device power events-only. With the bus no longer starved, the cheap `metering/getLatest` path returns valid data for dSM12.

## Verification

On a dSM12-only dSS (1.19.12), after this change all per-circuit sensors report correct values with no errors:

| sensor | before | after |
|---|---|---|
| `*_3f6_garage_aussen_power` | unavailable | `10 W` |
| `*_3f6_garage_aussen_energy` | unavailable | `200.0 kWh` |
| `*_3f5_kuche_power` | unavailable | `29 W` |
| apartment total | `1153 W` | `1153 W` (unchanged) |

`metering/getLatest` queried directly against the dSS confirmed it returns live per-dSM consumption for these dSM12 meters.

## Change

Only the EOL **dSM11** stays excluded; **dSM12** is treated like the other supported meters. One-line filter change + an updated comment.

If you''d prefer to gate this behind a config option instead of re-including dSM12 unconditionally, happy to adjust — but since the bus-starvation root cause is already fixed, including dSM12 should be safe for everyone. Thanks for the integration!

🤖 Generated with [Claude Code](https://claude.com/claude-code)