### PR TITLE
Fix TypeError in get_temperature when NominalValue is None (all entities go unavailable after a dSS restart)

### DIFF
--- a/custom_components/digitalstrom_smart/coordinator.py
+++ b/custom_components/digitalstrom_smart/coordinator.py
@@ -869,12 +869,19 @@ class DigitalStromCoordinator(DataUpdateCoordinator):
         1. apartment getTemperatureControlValues (NominalValue)
         2. per-zone getTemperatureControlStatus (NominalValue)
         """
+        # NominalValue can be *present but None* (the dSS sends it explicitly as
+        # null right after a restart/power outage, as the docstring notes). In
+        # that case dict.get(key, 0) returns None, not the default, so the bare
+        # `> 0` comparison raises TypeError. Guard the type to fall through to
+        # the next source instead of crashing.
         data = self._temperatures.get(zone_id)
-        if data and data.get("NominalValue", 0) > 0:
-            return data["NominalValue"]
+        nominal = data.get("NominalValue") if data else None
+        if isinstance(nominal, (int, float)) and nominal > 0:
+            return nominal
         status = self._climate_status.get(zone_id)
-        if status and status.get("NominalValue", 0) > 0:
-            return status["NominalValue"]
+        nominal = status.get("NominalValue") if status else None
+        if isinstance(nominal, (int, float)) and nominal > 0:
+            return nominal
         return None
 
     def _zone_device_temperature(self, zone_id: int) -> float | None:


### PR DESCRIPTION
## Problem

After a power outage (or any dSS restart) **all** `digitalstrom_smart` entities went `unavailable` — every per-circuit power/energy sensor and the apartment power-consumption sensor — even though the dSS itself was reachable and serving data the whole time.

The log filled up with:

```
ERROR (MainThread) [custom_components.digitalstrom_smart.coordinator] Unexpected error updating listener ... for digitalstrom_smart
  ...
  File ".../digitalstrom_smart/climate.py", line 142, in target_temperature
    return self.coordinator.get_temperature(self._zone_id)
  File ".../digitalstrom_smart/coordinator.py", line 876, in get_temperature
    if status and status.get("NominalValue", 0) > 0:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```

## Root cause

Right after a dSS restart the apartment temperature-control values come back with `NominalValue` **present but explicitly `None`** — exactly the situation the `get_temperature` docstring already calls out ("briefly read 0/None").

`dict.get("NominalValue", 0)` only substitutes the default `0` when the key is **absent**. When the key exists with value `None` it returns `None`, so `None > 0` raises `TypeError`.

That exception is raised from a climate entity's `_handle_coordinator_update` → `async_write_ha_state()` while the coordinator is iterating `async_update_listeners()`. Because it propagates out of the listener loop, every entity registered **after** the first climate entity — i.e. all the per-circuit power/energy sensors and the apartment consumption sensor — never gets its state written and goes `unavailable`, until the dSS happens to return a non-null setpoint again.

## Fix

Guard the comparison with an `isinstance` check, so a `None` (or unexpected `str`) `NominalValue` falls through to the next source instead of crashing. Behaviour is unchanged for valid numeric setpoints.

## Note

The same `.get(key, 0) > 0` idiom appears at two more spots for `output_mode` (around lines 1286/1306). Those haven't crashed in practice (output_mode is an int enum), but I'm happy to harden them in this PR as well if you'd prefer.

## Verification

On a dSM12-only installation, after the outage all power/energy sensors were `unavailable`. With this patch (after a restart) every sensor is live again with correct values and the `get_temperature` listener errors stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
