### PR TITLE
feat: expose dS button/rocker presses as event entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Unlike traditional per-device polling integrations, Digital Strom Smart uses the
 - **System scene switches** — trigger Panic, Fire/Brand, Alarm 1-4 and Doorbell apartment-wide from HA as switches (via `apartment/callScene`); each switch reads the real dSS state back, so it returns to off by itself if the dSS ignores the scene
 - **Environment states** — Day/Night, Twilight, Daylight and Holiday from the dSS as read-only binary sensors
 - **Event-driven** — instant state updates when someone uses a wall switch
+- **Button / rocker events** — dS pushbuttons and EnOcean rockers appear as `event` entities that fire on a physical press (event types for tap / double / hold per paddle), so a wall button can trigger HA automations directly
 - **Scenes for all groups** — Light, Shade, and Heating scenes
 
 ### Pro
@@ -131,6 +132,9 @@ For each zone with devices:
 Individual Joker devices:
 - `switch.<zone>_<device_name>` — Per-device on/off control (actuators with outputMode > 0)
 - `binary_sensor.<zone>_<device_name>` — Contact/smoke/door sensors (devices with outputMode == 0)
+
+Buttons / rockers:
+- `event.<button_name>` — fires on a physical dS pushbutton / EnOcean rocker press (device class `button`; event types like `up_single`, `down_single`, `up_hold`, derived from the dSS `buttonClick`). Devices that emit a `buttonClick` are picked up automatically on first press; buttons configured to call a scene (which emit `callScene` instead, with no per-device source) are not exposed individually.
 
 Device-level sensors (Ulux, etc.):
 - `sensor.<zone>_<device>_temperature` — Device temperature

--- a/custom_components/digitalstrom_smart/__init__.py
+++ b/custom_components/digitalstrom_smart/__init__.py
@@ -31,7 +31,7 @@ from .license import check_pro_license as _check_pro_license, sync_pro_issue
 
 # Pre-import all platform modules to avoid blocking imports in event loop (HA 2026+)
 from . import (  # noqa: F401
-    light, cover, sensor, scene, switch, climate, binary_sensor, select, button,
+    light, cover, sensor, scene, switch, climate, binary_sensor, select, button, event,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/digitalstrom_smart/api.py
+++ b/custom_components/digitalstrom_smart/api.py
@@ -961,6 +961,7 @@ class DigitalStromApi:
         event_names = [
             "callScene",
             "undoScene",
+            "buttonClick",
             "zoneSensorValue",
             "stateChange",
             "addonStateChange",   # user-defined states (system-addon-user-defined-states)

--- a/custom_components/digitalstrom_smart/const.py
+++ b/custom_components/digitalstrom_smart/const.py
@@ -9,7 +9,7 @@ MANUFACTURER = "Digital Strom"
 INTEGRATION_AUTHOR = "Woon IoT BV"
 INTEGRATION_AUTHOR_ID = "MN-HJD-2026"
 INTEGRATION_URL = "https://github.com/wooniot/ha-digitalstrom-smart"
-INTEGRATION_VERSION = "4.1.9"
+INTEGRATION_VERSION = "4.2.0"
 
 # Application name shown in dSS Configurator under registered applications
 DSS_APP_NAME = "WoonIoT HA Connect"
@@ -467,13 +467,36 @@ CONF_PRO_LICENSE = "pro_license_key"
 
 # --- Platforms ---
 # Free platforms (always loaded)
-PLATFORMS_FREE = ["light", "cover", "sensor", "scene", "switch", "binary_sensor", "button"]
+PLATFORMS_FREE = ["light", "cover", "sensor", "scene", "switch", "binary_sensor", "button", "event"]
 
 # Pro platforms (requires license)
 PLATFORMS_PRO = ["climate", "select"]
 
 # All platforms
 PLATFORMS = PLATFORMS_FREE + PLATFORMS_PRO
+
+
+# --- Button / rocker press events (event platform) ---
+# dSS functionIDs identifying pushbutton / rocker devices that emit `buttonClick`
+# events. 33030 = EnOcean rocker switch (F6-02-FF). `buttonInputs` is not
+# reliably populated for bridged plan44/EnOcean rockers, so we key off functionID.
+BUTTON_FUNCTION_IDS = {33030}
+
+# dSS clickType -> readable HA event-type suffix.
+BUTTON_CLICK_TYPE_NAMES = {
+    0: "single", 1: "double", 2: "triple", 3: "quadruple",
+    4: "hold", 5: "hold_repeat", 6: "hold_release",
+    7: "single", 8: "double", 9: "triple",
+    10: "short_long", 11: "local_off", 12: "local_on",
+    13: "short_short_long", 14: "local_stop",
+}
+# dSS buttonIndex (buttonElementID) -> readable HA event-type prefix.
+BUTTON_ELEMENT_NAMES = {0: "button", 1: "down", 2: "up"}
+
+
+def signal_button_event(entry_id: str) -> str:
+    """Dispatcher signal carrying a dSS buttonClick for one config entry."""
+    return f"{DOMAIN}_button_event_{entry_id}"
 
 # --- User Defined States ---
 # State source that marks an entry as a true User Defined Action (set in dSS Configurator)

--- a/custom_components/digitalstrom_smart/coordinator.py
+++ b/custom_components/digitalstrom_smart/coordinator.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import DigitalStromApi, DigitalStromApiError, DigitalStromAuthError
@@ -19,6 +20,8 @@ import aiohttp
 
 from .const import (
     DOMAIN,
+    BUTTON_FUNCTION_IDS,
+    signal_button_event,
     POLL_INTERVAL_ENERGY,
     POLL_INTERVAL_BINARY,
     RECONNECT_INITIAL,
@@ -181,6 +184,18 @@ class DigitalStromCoordinator(DataUpdateCoordinator):
         self.entry_id: str | None = None
         self._license_last_check: float = 0.0
 
+    def button_devices(self) -> dict[str, dict]:
+        """Devices that emit dSS ``buttonClick`` events (rockers / pushbuttons).
+
+        Identified by dSS ``functionID`` because ``buttonInputs`` is not reliably
+        populated for bridged plan44/EnOcean rocker devices. Keyed by dSUID.
+        """
+        return {
+            dsuid: dev
+            for dsuid, dev in self.devices.items()
+            if dev.get("function_id") in BUTTON_FUNCTION_IDS
+        }
+
     def _parse_structure(self, structure: dict) -> None:
         """Parse apartment structure into zone and device dicts."""
         apartment = structure.get("apartment", structure)
@@ -231,6 +246,7 @@ class DigitalStromCoordinator(DataUpdateCoordinator):
                     "hw_info": dev.get("hwInfo", ""),
                     "is_on": dev.get("isOn", False),
                     "output_mode": dev.get("outputMode", 0),
+                    "function_id": dev.get("functionID"),
                     "binary_inputs": dev.get("binaryInputs", []),
                     "groups": [],
                     "sensors": [],
@@ -1461,6 +1477,21 @@ class DigitalStromCoordinator(DataUpdateCoordinator):
                 "Raw stateChange event: raw_props_type=%s props=%s",
                 type(raw_props).__name__, props,
             )
+
+        if name == "buttonClick":
+            source = event.get("source") or {}
+            dsuid = source.get("dsid") or source.get("dSUID") or ""
+            if dsuid and self.entry_id:
+                async_dispatcher_send(
+                    self.hass,
+                    signal_button_event(self.entry_id),
+                    {
+                        "dsuid": dsuid,
+                        "button_index": props.get("buttonIndex"),
+                        "click_type": props.get("clickType"),
+                    },
+                )
+            return
 
         if name in ("callScene", "undoScene"):
             zone_id = int(props.get("zoneID", 0))

--- a/custom_components/digitalstrom_smart/event.py
+++ b/custom_components/digitalstrom_smart/event.py
@@ -1,9 +1,16 @@
 """Event entities for Digital Strom button / rocker presses.
 
-Each dS pushbutton or EnOcean rocker (identified by functionID) becomes an
-``event`` entity that fires when the physical button is pressed. Driven by the
-dSS ``buttonClick`` event stream, delivered in real time through the coordinator
-event loop — no polling.
+Every dS pushbutton or EnOcean rocker becomes an ``event`` entity that fires
+when the physical button is pressed, driven by the dSS ``buttonClick`` event
+stream (real time, via the coordinator event loop — no polling).
+
+Discovery is twofold:
+  * up front, devices whose dSS functionID marks them as a rocker/button
+    (``BUTTON_FUNCTION_IDS``) so their entities exist immediately after start,
+    plus any button entity already in the registry from a previous run;
+  * dynamically, the first time a ``buttonClick`` arrives for a device we have
+    not seen yet — this covers every other dS pushbutton type automatically
+    without maintaining a functionID allow-list.
 """
 
 import logging
@@ -11,6 +18,7 @@ import logging
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -24,6 +32,8 @@ from .const import (
 from .coordinator import DigitalStromCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+_UNIQUE_PREFIX = "button_"
 
 # Every event type an entity may fire: each element prefix x each click-name
 # suffix, plus a fallback for click types we do not map.
@@ -56,13 +66,49 @@ async def async_setup_entry(
 ) -> None:
     """Set up Digital Strom button event entities."""
     coordinator: DigitalStromCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    entities = [
-        DigitalStromButtonEvent(coordinator, entry.entry_id, dsuid, dev)
-        for dsuid, dev in coordinator.button_devices().items()
-    ]
+    dss_id = coordinator.dss_id
+    uid_prefix = f"ds_{dss_id}_{_UNIQUE_PREFIX}"
+    known: set[str] = set()
+
+    def _make(dsuid: str, initial: dict | None = None) -> "DigitalStromButtonEvent":
+        known.add(dsuid.lower())
+        dev = coordinator.devices.get(dsuid) or coordinator.devices.get(dsuid.lower()) or {}
+        return DigitalStromButtonEvent(coordinator, entry.entry_id, dsuid, dev, initial)
+
+    entities: list[DigitalStromButtonEvent] = []
+
+    # 1. Up-front: devices whose functionID marks them as a button/rocker.
+    for dsuid in coordinator.button_devices():
+        entities.append(_make(dsuid))
+
+    # 2. Restore any button entity discovered on a previous run so it survives a
+    #    restart before its next press.
+    ent_reg = er.async_get(hass)
+    for entity in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        if entity.domain == "event" and entity.unique_id.startswith(uid_prefix):
+            dsuid = entity.unique_id[len(uid_prefix):]
+            if dsuid.lower() not in known:
+                entities.append(_make(dsuid))
+
     if entities:
         _LOGGER.info("Adding %d Digital Strom button event entities", len(entities))
     async_add_entities(entities)
+
+    # 3. Dynamic discovery: first buttonClick from an unknown device -> new entity.
+    @callback
+    def _discover(payload: dict) -> None:
+        raw = payload.get("dsuid") or ""
+        if not raw or raw.lower() in known:
+            return
+        _LOGGER.info(
+            "Discovered new Digital Strom button device %s (%s)",
+            raw, (coordinator.devices.get(raw) or {}).get("name") or "?",
+        )
+        async_add_entities([_make(raw, initial=payload)])
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, signal_button_event(entry.entry_id), _discover)
+    )
 
 
 class DigitalStromButtonEvent(EventEntity):
@@ -81,11 +127,13 @@ class DigitalStromButtonEvent(EventEntity):
         entry_id: str,
         dsuid: str,
         dev: dict,
+        initial: dict | None = None,
     ) -> None:
         self._entry_id = entry_id
         self._dsuid = dsuid.lower()
+        self._initial = initial
         dss_id = coordinator.dss_id
-        self._attr_unique_id = f"ds_{dss_id}_button_{dsuid}"
+        self._attr_unique_id = f"ds_{dss_id}_{_UNIQUE_PREFIX}{dsuid}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, dsuid)},
             "name": dev.get("name") or dsuid,
@@ -103,6 +151,11 @@ class DigitalStromButtonEvent(EventEntity):
                 self._handle_button_event,
             )
         )
+        # If this entity was created by the dynamic-discovery press, fire that
+        # first event now (it arrived before we were listening).
+        if self._initial is not None:
+            initial, self._initial = self._initial, None
+            self._handle_button_event(initial)
 
     @callback
     def _handle_button_event(self, payload: dict) -> None:

--- a/custom_components/digitalstrom_smart/event.py
+++ b/custom_components/digitalstrom_smart/event.py
@@ -1,0 +1,120 @@
+"""Event entities for Digital Strom button / rocker presses.
+
+Each dS pushbutton or EnOcean rocker (identified by functionID) becomes an
+``event`` entity that fires when the physical button is pressed. Driven by the
+dSS ``buttonClick`` event stream, delivered in real time through the coordinator
+event loop — no polling.
+"""
+
+import logging
+
+from homeassistant.components.event import EventDeviceClass, EventEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    BUTTON_CLICK_TYPE_NAMES,
+    BUTTON_ELEMENT_NAMES,
+    DOMAIN,
+    MANUFACTURER,
+    signal_button_event,
+)
+from .coordinator import DigitalStromCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Every event type an entity may fire: each element prefix x each click-name
+# suffix, plus a fallback for click types we do not map.
+EVENT_TYPES: list[str] = [
+    f"{element}_{name}"
+    for element in dict.fromkeys(BUTTON_ELEMENT_NAMES.values())
+    for name in dict.fromkeys(BUTTON_CLICK_TYPE_NAMES.values())
+] + ["unknown"]
+
+
+def _event_type(button_index: object, click_type: object) -> str:
+    """Map a dSS (buttonIndex, clickType) pair to a stable HA event type."""
+    try:
+        element = BUTTON_ELEMENT_NAMES.get(int(button_index), "button")  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        element = "button"
+    try:
+        name = BUTTON_CLICK_TYPE_NAMES.get(int(click_type))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        name = None
+    if name is None:
+        return "unknown"
+    return f"{element}_{name}"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Digital Strom button event entities."""
+    coordinator: DigitalStromCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities = [
+        DigitalStromButtonEvent(coordinator, entry.entry_id, dsuid, dev)
+        for dsuid, dev in coordinator.button_devices().items()
+    ]
+    if entities:
+        _LOGGER.info("Adding %d Digital Strom button event entities", len(entities))
+    async_add_entities(entities)
+
+
+class DigitalStromButtonEvent(EventEntity):
+    """A dS pushbutton / rocker exposed as a Home Assistant event entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_icon = "mdi:gesture-tap-button"
+    _attr_device_class = EventDeviceClass.BUTTON
+    _attr_event_types = EVENT_TYPES
+
+    def __init__(
+        self,
+        coordinator: DigitalStromCoordinator,
+        entry_id: str,
+        dsuid: str,
+        dev: dict,
+    ) -> None:
+        self._entry_id = entry_id
+        self._dsuid = dsuid.lower()
+        dss_id = coordinator.dss_id
+        self._attr_unique_id = f"ds_{dss_id}_button_{dsuid}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, dsuid)},
+            "name": dev.get("name") or dsuid,
+            "manufacturer": MANUFACTURER,
+            "model": dev.get("hw_info") or "Button",
+            "via_device": (DOMAIN, f"{dss_id}_apartment"),
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to buttonClick events for this device."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                signal_button_event(self._entry_id),
+                self._handle_button_event,
+            )
+        )
+
+    @callback
+    def _handle_button_event(self, payload: dict) -> None:
+        """Fire the HA event when a buttonClick for this device arrives."""
+        if (payload.get("dsuid") or "").lower() != self._dsuid:
+            return
+        event_type = _event_type(payload.get("button_index"), payload.get("click_type"))
+        self._trigger_event(
+            event_type,
+            {
+                "button_index": payload.get("button_index"),
+                "click_type": payload.get("click_type"),
+            },
+        )
+        self.async_write_ha_state()

--- a/custom_components/digitalstrom_smart/manifest.json
+++ b/custom_components/digitalstrom_smart/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/wooniot/ha-digitalstrom-smart/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "4.1.9"
+  "version": "4.2.0"
 }


### PR DESCRIPTION
## What

Adds an `event` platform so dS pushbuttons / EnOcean rockers become Home Assistant `event` entities that fire on a physical press — usable directly as automation triggers, no polling.

Each button device becomes one `event` entity (device_class `button`); event types are derived from the dSS `buttonClick` (`buttonIndex` → `down`/`up`, `clickType` → `single`/`double`/`hold`/`hold_release`/…).

## Why

Button/rocker presses were not surfaced to HA at all. The integration already runs a real-time dSS event listener (`callScene`, `stateChange`, …) but never exposed the raw button press, so you could not trigger an automation from a wall button / rocker.

## How

- `api.subscribe_events`: also subscribe to `buttonClick`
- `coordinator._process_event`: route `buttonClick` to a per-entry dispatcher signal (`signal_button_event(entry_id)`); capture each device's `functionID` in `dev_info`; add `button_devices()` discovery
- `event.py` (new): one `DigitalStromButtonEvent` per button device
  - **up front** for devices whose `functionID` marks them a rocker/button, plus any button entity already in the registry (so they survive a restart before the next press)
  - **dynamically** the first time a `buttonClick` arrives from an unseen device — every button type is covered without maintaining a functionID allow-list
- version → 4.2.0

## Verified live

Tested against a P44-DSB-E2 bridge with EnOcean F6-02 rockers:
- a press produces a dSS `buttonClick` (`buttonIndex` 1/2, `clickType` 0) that now fires the matching `event` entity in real time (`event_type` e.g. `up_single` / `down_single`)
- entities register at setup and restore their last event across restarts

## Note / limitation

Only buttons that emit a `buttonClick` are exposed per device. A button configured to call a scene (e.g. a light-group pushbutton) emits `callScene` instead, whose event source is the zone/dSM rather than the device — so it cannot be mapped to a specific button. Such a button can be switched to the Joker group in the Configurator to emit a raw `buttonClick`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
